### PR TITLE
firefly // Disable pre-pull and continuous image pull by default

### DIFF
--- a/charts/firefly/Chart.yaml
+++ b/charts/firefly/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: firefly
 description: Hyperdrive Notebooks and Community Edition
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.2.0"
 dependencies:
   - name: nginx-ingress-controller

--- a/charts/firefly/values.yaml
+++ b/charts/firefly/values.yaml
@@ -2,6 +2,11 @@ nginx-ingress-controller:
   enabled: false
 
 jupyterhub:
+  prePuller:
+    hook:
+      enabled: false
+    continuous:
+      enabled: false
   proxy:
     service:
       type: ClusterIP


### PR DESCRIPTION
In order to conserve resources in local deployments, we should disable the image pullers by default. These are helm values which can be flipped and enabled by users who want them.
